### PR TITLE
Add features to request() to support cancellation upon timeout in mirai

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nanonext
 Type: Package
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.5.2.9000
+Version: 1.5.2.9001
 Description: R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ. NNG is
     a socket library for reliable, high-performance messaging over in-process,
     IPC, TCP, WebSocket and secure TLS transports. Implements 'Scalability

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # nanonext (development version)
 
+#### New Features
+
+* `request()` gains an integer argument `msgid`. This may be specified to have a special payload sent asynchronously upon timeout (to communicate with the connected party).
+
 #### Updates
 
 * More robust interruption on non-Windows platforms if `tools::SIGINT` is supplied or passed through to the `autoexit` argument of `daemon()` (thanks @LennardLux, #97).

--- a/R/context.R
+++ b/R/context.R
@@ -181,6 +181,7 @@ reply <- function(context,
 #' @param cv (optional) a 'conditionVariable' to signal when the async receive
 #'   is complete, or NULL. If any other value is supplied, this will cause the
 #'   pipe connection to be dropped when the async receive is complete.
+#' @param msgid (optional) integer message ID.
 #'
 #' @return A 'recvAio' (object of class 'mirai' and 'recvAio') (invisibly).
 #'
@@ -227,5 +228,6 @@ request <- function(context,
                     recv_mode = c("serial", "character", "complex", "double",
                                   "integer", "logical", "numeric", "raw", "string"),
                     timeout = NULL,
-                    cv = NULL)
-  data <- .Call(rnng_request, context, data, send_mode, recv_mode, timeout, cv, environment())
+                    cv = NULL,
+                    msgid = NULL)
+  data <- .Call(rnng_request, context, data, send_mode, recv_mode, timeout, cv, msgid, environment())

--- a/R/context.R
+++ b/R/context.R
@@ -181,7 +181,9 @@ reply <- function(context,
 #' @param cv (optional) a 'conditionVariable' to signal when the async receive
 #'   is complete, or NULL. If any other value is supplied, this will cause the
 #'   pipe connection to be dropped when the async receive is complete.
-#' @param msgid (optional) integer message ID.
+#' @param msgid (optional) integer message ID to send a special payload to the
+#'   context upon timeout (asynchronously) consisting of an integer zero,
+#'   followed by the value of `msgid` supplied.
 #'
 #' @return A 'recvAio' (object of class 'mirai' and 'recvAio') (invisibly).
 #'

--- a/man/request.Rd
+++ b/man/request.Rd
@@ -38,7 +38,9 @@ applies a socket-specific default, usually the same as no timeout.}
 is complete, or NULL. If any other value is supplied, this will cause the
 pipe connection to be dropped when the async receive is complete.}
 
-\item{msgid}{(optional) integer message ID.}
+\item{msgid}{(optional) integer message ID to send a special payload to the
+context upon timeout (asynchronously) consisting of an integer zero,
+followed by the value of \code{msgid} supplied.}
 }
 \value{
 A 'recvAio' (object of class 'mirai' and 'recvAio') (invisibly).

--- a/man/request.Rd
+++ b/man/request.Rd
@@ -11,7 +11,8 @@ request(
   recv_mode = c("serial", "character", "complex", "double", "integer", "logical",
     "numeric", "raw", "string"),
   timeout = NULL,
-  cv = NULL
+  cv = NULL,
+  msgid = NULL
 )
 }
 \arguments{
@@ -36,6 +37,8 @@ applies a socket-specific default, usually the same as no timeout.}
 \item{cv}{(optional) a 'conditionVariable' to signal when the async receive
 is complete, or NULL. If any other value is supplied, this will cause the
 pipe connection to be dropped when the async receive is complete.}
+
+\item{msgid}{(optional) integer message ID.}
 }
 \value{
 A 'recvAio' (object of class 'mirai' and 'recvAio') (invisibly).

--- a/src/init.c
+++ b/src/init.c
@@ -147,7 +147,7 @@ static const R_CallMethodDef callMethods[] = {
   {"rnng_reap", (DL_FUNC) &rnng_reap, 1},
   {"rnng_recv", (DL_FUNC) &rnng_recv, 4},
   {"rnng_recv_aio", (DL_FUNC) &rnng_recv_aio, 6},
-  {"rnng_request", (DL_FUNC) &rnng_request, 7},
+  {"rnng_request", (DL_FUNC) &rnng_request, 8},
   {"rnng_send", (DL_FUNC) &rnng_send, 5},
   {"rnng_send_aio", (DL_FUNC) &rnng_send_aio, 6},
   {"rnng_serial_config", (DL_FUNC) &rnng_serial_config, 4},

--- a/src/init.c
+++ b/src/init.c
@@ -14,6 +14,7 @@ SEXP nano_HeadersSymbol;
 SEXP nano_IdSymbol;
 SEXP nano_ListenerSymbol;
 SEXP nano_MonitorSymbol;
+SEXP nano_MsgidSymbol;
 SEXP nano_ProtocolSymbol;
 SEXP nano_ResolveSymbol;
 SEXP nano_ResponseSymbol;
@@ -48,6 +49,7 @@ static void RegisterSymbols(void) {
   nano_IdSymbol = Rf_install("id");
   nano_ListenerSymbol = Rf_install("listener");
   nano_MonitorSymbol = Rf_install("monitor");
+  nano_MsgidSymbol = Rf_install("msgid");
   nano_ProtocolSymbol = Rf_install("protocol");
   nano_ResolveSymbol = Rf_install("resolve");
   nano_ResponseSymbol = Rf_install("response");

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -157,19 +157,19 @@ typedef enum nano_aio_typ {
 
 typedef struct nano_aio_s {
   nng_aio *aio;
-  nng_ctx *ctx;
   void *data;
   void *cb;
   void *next;
   int result;
-  int msgid;
   uint8_t mode;
   nano_aio_typ type;
 } nano_aio;
 
 typedef struct nano_saio_s {
+  nng_ctx *ctx;
   nng_aio *aio;
   void *cb;
+  int msgid;
 } nano_saio;
 
 typedef struct nano_cv_s {

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -157,10 +157,12 @@ typedef enum nano_aio_typ {
 
 typedef struct nano_aio_s {
   nng_aio *aio;
+  nng_ctx *ctx;
   void *data;
   void *cb;
   void *next;
   int result;
+  int msgid;
   uint8_t mode;
   nano_aio_typ type;
 } nano_aio;
@@ -315,7 +317,7 @@ SEXP rnng_random(SEXP, SEXP);
 SEXP rnng_reap(SEXP);
 SEXP rnng_recv(SEXP, SEXP, SEXP, SEXP);
 SEXP rnng_recv_aio(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
-SEXP rnng_request(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
+SEXP rnng_request(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 SEXP rnng_send(SEXP, SEXP, SEXP, SEXP, SEXP);
 SEXP rnng_send_aio(SEXP, SEXP, SEXP, SEXP, SEXP, SEXP);
 SEXP rnng_serial_config(SEXP, SEXP, SEXP, SEXP);

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -216,6 +216,7 @@ extern SEXP nano_HeadersSymbol;
 extern SEXP nano_IdSymbol;
 extern SEXP nano_ListenerSymbol;
 extern SEXP nano_MonitorSymbol;
+extern SEXP nano_MsgidSymbol;
 extern SEXP nano_ProtocolSymbol;
 extern SEXP nano_ResolveSymbol;
 extern SEXP nano_ResponseSymbol;

--- a/src/sync.c
+++ b/src/sync.c
@@ -27,7 +27,7 @@ static void request_complete(void *arg) {
     const int id = saio->msgid;
     if (id) {
       nng_msg *msg;
-      if (nng_msg_alloc(&msg, 0)) {
+      if (nng_msg_alloc(&msg, 0) == 0) {
         if (nng_msg_append_u32(msg, 0) ||
             nng_msg_append(msg, &id, sizeof(id)) ||
             nng_ctx_sendmsg(*saio->ctx, msg, 0)) {


### PR DESCRIPTION
Need to pass through `msgid` and have it send the required payload in the recv aio callback in case of a timeout.