### PR TITLE
Efficiency / Performance Enhancements to mirai Cancellation Support

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: nanonext
 Type: Package
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.5.2.9001
+Version: 1.5.2.9002
 Description: R binding for NNG (Nanomsg Next Gen), a successor to ZeroMQ. NNG is
     a socket library for reliable, high-performance messaging over in-process,
     IPC, TCP, WebSocket and secure TLS transports. Implements 'Scalability

--- a/src/sync.c
+++ b/src/sync.c
@@ -449,7 +449,8 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   PROTECT(env = R_NewEnv(R_NilValue, 0, 0));
   Rf_classgets(env, nano_reqAio);
   Rf_defineVar(nano_AioSymbol, aio, env);
-  Rf_setAttrib(env, nano_MsgidSymbol, msgid);
+  Rf_defineVar(nano_MsgidSymbol, msgid, env);
+  Rf_defineVar(nano_ContextSymbol, con, env);
 
   PROTECT(fun = R_mkClosure(R_NilValue, nano_aioFuncMsg, clo));
   R_MakeActiveBinding(nano_DataSymbol, fun, env);

--- a/src/sync.c
+++ b/src/sync.c
@@ -449,7 +449,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   PROTECT(env = R_NewEnv(R_NilValue, 0, 0));
   Rf_classgets(env, nano_reqAio);
   Rf_defineVar(nano_AioSymbol, aio, env);
-  Rf_defineVar(nano_MsgidSymbol, msgid, env);
+  Rf_defineVar(nano_MsgidSymbol, Rf_ScalarInteger(id), env);
   Rf_defineVar(nano_ContextSymbol, con, env);
 
   PROTECT(fun = R_mkClosure(R_NilValue, nano_aioFuncMsg, clo));


### PR DESCRIPTION
By making the context accessible, we can use it directly to send the cancellation request, without having to worry about compute profiles and the such in mirai.