### PR TITLE
Additional safety for memcpy on zero-length R vectors

### DIFF
--- a/src/tls.c
+++ b/src/tls.c
@@ -101,7 +101,8 @@ SEXP rnng_random(SEXP n, SEXP convert) {
     out = nano_hash_char(buf, sz);
   } else {
     out = Rf_allocVector(RAWSXP, sz);
-    memcpy(NANO_DATAPTR(out), buf, sz);
+    if (sz)
+      memcpy(NANO_DATAPTR(out), buf, sz);
   }
 
   return out;


### PR DESCRIPTION
There's no sign that nanonext is affected by the issues at https://github.com/r-lib/vctrs/pull/1968, but this PR takes a conservative approach to avoid these potentially 'poisoned' pointers.