### PR TITLE
write_stdout() automatically appends newline

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -305,12 +305,15 @@ serial_config <- function(class, sfunc, ufunc, vec = FALSE)
 #' This function writes to the C-level `stdout` of the process and hence cannot
 #' be re-directed by [sink()].
 #'
+#' A newline character is automatically appended to `x`, hence there is no need
+#' to include this within the input string.
+#'
 #' @param x character string.
 #'
 #' @return Invisible NULL. As a side effect, `x` is output to `stdout`.
 #'
 #' @examples
-#' write_stdout("\n")
+#' write_stdout("")
 #'
 #' @export
 #'

--- a/man/write_stdout.Rd
+++ b/man/write_stdout.Rd
@@ -19,8 +19,11 @@ Avoids interleaved output when writing concurrently from multiple processes.
 \details{
 This function writes to the C-level \code{stdout} of the process and hence cannot
 be re-directed by \code{\link[=sink]{sink()}}.
+
+A newline character is automatically appended to \code{x}, hence there is no need
+to include this within the input string.
 }
 \examples{
-write_stdout("\n")
+write_stdout("")
 
 }

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -53,6 +53,7 @@ typedef struct nano_handle_s {
 #include <windows.h>
 #else
 #include <unistd.h>
+#include <sys/uio.h>
 #include <ifaddrs.h>
 #include <arpa/inet.h>
 #include <net/if.h>

--- a/src/net.c
+++ b/src/net.c
@@ -84,10 +84,17 @@ SEXP rnng_write_stdout(SEXP x) {
 
   const char *buf = CHAR(STRING_ELT(x, 0));
 #ifdef _WIN32
+  char nbuf[strlen(buf) + 2];
+  snprintf(nbuf, sizeof(nbuf), "%s\n", buf);
   DWORD bytes;
-  if (WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), buf, (DWORD) strlen(buf), &bytes, NULL)) {}
+  if (WriteFile(GetStdHandle(STD_OUTPUT_HANDLE), nbuf, (DWORD) strlen(nbuf), &bytes, NULL)) {}
 #else
-  if (write(1, buf, strlen(buf))) {}
+  struct iovec iov[2];
+  iov[0].iov_base = (void *) buf;
+  iov[0].iov_len = strlen(buf);
+  iov[1].iov_base = "\n";
+  iov[1].iov_len = 1;
+  if (writev(STDOUT_FILENO, iov, 2)) {}
 #endif
   return R_NilValue;
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -631,7 +631,7 @@ if (promises) later::run_now(1L)
 if (promises) test_zero(close(s1))
 if (promises) test_zero(close(s))
 if (promises) later::run_now(1L)
-test_null(write_stdout("\n"))
+test_null(write_stdout(""))
 test_type("character", ip_addr())
 
 test_true(.interrupt())


### PR DESCRIPTION
Have `write_stdout()` automatically append a newline. Uses efficient zero-copy `writev()` syscall and iov structures on unix-like systems.