### PR TITLE
Ensure send_aio() always sends

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nanonext
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.5.2.9011
+Version: 1.5.2.9012
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,8 +10,10 @@
   + Gains integer argument `msgid`. This may be specified to have a special payload sent asynchronously upon timeout (to communicate with the connected party).
   + Accepts a 'req' socket, in which case a single-use context is created automatically for the request.
 * `serial_config()` now accepts vector arguments to register multiple custom serialization configurations.
+
 #### Updates
 
+* `send_aio()` without keeping a reference to the return value no longer potentially drops sends (thanks @wch, #129).
 * More robust interruption on non-Windows platforms if `tools::SIGINT` is supplied or passed through to the `autoexit` argument of `daemon()` (thanks @LennardLux, #97).
 * Installation from source specifying 'INCLUDE_DIR' and 'LIB_DIR' environment variables works again, correcting a regression in v1.5.2 (#104).
 * Windows bi-arch source builds for R <= 4.1 using rtools40 and earlier work again (regression since v1.5.1) (thanks @daroczig, #107).

--- a/src/aio.c
+++ b/src/aio.c
@@ -165,6 +165,8 @@ static void saio_finalizer(SEXP xptr) {
 
   if (xp->mode == 0x1) {
     nng_aio_free(xp->aio);
+    if (xp->data != NULL)
+      R_Free(xp->data);
     R_Free(xp);
   } else {
     xp->mode = 0x1;

--- a/src/init.c
+++ b/src/init.c
@@ -198,6 +198,7 @@ void attribute_visible R_init_nanonext(DllInfo* dll) {
 // # nocov start
 void attribute_visible R_unload_nanonext(DllInfo *info) {
   rnng_thread_shutdown();
+  nano_list_op(0, NULL);
   ReleaseObjects();
 }
 // # nocov end

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -301,7 +301,7 @@ int nano_matchargs(const SEXP);
 void pipe_cb_signal(nng_pipe, nng_pipe_ev, void *);
 void tls_finalizer(SEXP);
 
-void nano_list_op(int, void *);
+void nano_list_op(int, nano_aio *);
 
 SEXP rnng_advance_rng_state(void);
 SEXP rnng_aio_call(SEXP);

--- a/src/nanonext.h
+++ b/src/nanonext.h
@@ -232,6 +232,11 @@ typedef struct nano_serial_bundle_s {
   SEXP hook_func;
 } nano_serial_bundle;
 
+typedef struct nano_node_s {
+  void *data;
+  struct nano_node_s *next;
+} nano_node;
+
 extern void (*eln2)(void (*)(void *), void *, double, int);
 
 extern SEXP nano_AioSymbol;
@@ -295,6 +300,8 @@ int nano_matchargs(const SEXP);
 
 void pipe_cb_signal(nng_pipe, nng_pipe_ev, void *);
 void tls_finalizer(SEXP);
+
+void nano_list_op(int, void *);
 
 SEXP rnng_advance_rng_state(void);
 SEXP rnng_aio_call(SEXP);

--- a/src/net.c
+++ b/src/net.c
@@ -105,4 +105,3 @@ SEXP rnng_write_stdout(SEXP x) {
   return R_NilValue;
 
 }
-


### PR DESCRIPTION
Fixes #129.

It's cleaner for a finalizer to tie C and R object lifetimes together, but in this case I run resource cleanup from the aio completion callback (if this is a later event).

I actually add the aio to a 'free list' as the aio cannot free itself from its own callback. A clean operation on the list is then invoked every time `send_aio()` is called (and on unload). Of course, another possibility is for the aio callback to invoke `later`, but this is a core function and `later` is only an optional dependency.