### PR TITLE
Optimize send_aio() finalization

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Type: Package
 Package: nanonext
 Title: NNG (Nanomsg Next Gen) Lightweight Messaging Library
-Version: 1.5.2.9019
+Version: 1.5.2.9020
 Authors@R: c(
     person("Charlie", "Gao", , "charlie.gao@shikokuchuo.net", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-0750-061X")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -343,8 +343,8 @@ read_stdin <- function() .Call(rnng_read_stdin, interactive())
 #' vector if there are multiple addresses from multiple network adapters, or
 #' an empty character string if unavailable.
 #'
-#' The IP addresses will be named by interface e.g. 'eth0' or 'en0' (friendly
-#' names on Windows).
+#' The IP addresses will be named by interface (adapter friendly name on
+#' Windows) e.g. 'eth0' or 'en0'.
 #'
 #' @return A named character string.
 #'

--- a/README.Rmd
+++ b/README.Rmd
@@ -57,6 +57,7 @@ Web utilities:
 
 - [ncurl](https://nanonext.r-lib.org/articles/nanonext.html#ncurl-async-http-client) - (async) http(s) client
 - [stream](https://nanonext.r-lib.org/articles/nanonext.html#stream-websocket-client) - secure websockets client / generic low-level socket interface
+- `ip_addr()` - for retrieving all local network IP addresses by interface
 - `messenger()` - console-based instant messaging with authentication
 
 ### Quick Start

--- a/README.md
+++ b/README.md
@@ -72,6 +72,8 @@ Web utilities:
   (async) http(s) client
 - [stream](https://nanonext.r-lib.org/articles/nanonext.html#stream-websocket-client) -
   secure websockets client / generic low-level socket interface
+- `ip_addr()` - for retrieving all local network IP addresses by
+  interface
 - `messenger()` - console-based instant messaging with authentication
 
 ### Quick Start

--- a/man/ip_addr.Rd
+++ b/man/ip_addr.Rd
@@ -15,8 +15,8 @@ vector if there are multiple addresses from multiple network adapters, or
 an empty character string if unavailable.
 }
 \details{
-The IP addresses will be named by interface e.g. 'eth0' or 'en0' (friendly
-names on Windows).
+The IP addresses will be named by interface (adapter friendly name on
+Windows) e.g. 'eth0' or 'en0'.
 }
 \examples{
 ip_addr()

--- a/src/core.c
+++ b/src/core.c
@@ -540,11 +540,14 @@ int nano_encode_mode(const SEXP mode) {
   const char *mod = CHAR(STRING_ELT(mode, 0));
   const size_t slen = strlen(mod);
 
-  if (slen == 6 && !memcmp(mod, "serial", slen))
-    return 0;
-
-  if (slen == 3 && !memcmp(mod, "raw", slen))
-    return 1;
+  switch (slen) {
+  case 3:
+    if (!memcmp(mod, "raw", slen)) return 1;
+    break;
+  case 6:
+    if (!memcmp(mod, "serial", slen)) return 0;
+    break;
+  }
 
   Rf_error("`mode` should be one of: serial, raw");
 


### PR DESCRIPTION
Follow up to #130 and #131. Ensures GC actions still all happen during GC. Finalizers now check the linked list and perform frees if required. The `FREE` branch is now only called recursively by other `nano_list_do()` branches under lock.