### PR TITLE
Some improvements to the cURL interface

### DIFF
--- a/man/ncurl.Rd
+++ b/man/ncurl.Rd
@@ -37,7 +37,7 @@ A non-character or non-named vector will be ignored.}
 
 \item{data}{(optional) character string request data to be submitted. If a
 vector, only the first element is taken, and non-character objects are
-ignored.}
+ignored. Alternatively a raw vector giving the data to transfer directly}
 
 \item{response}{(optional) a character vector specifying the response headers
 to return e.g. \code{c("date", "server")}. These are case-insensitive and

--- a/man/ncurl_aio.Rd
+++ b/man/ncurl_aio.Rd
@@ -32,7 +32,7 @@ A non-character or non-named vector will be ignored.}
 
 \item{data}{(optional) character string request data to be submitted. If a
 vector, only the first element is taken, and non-character objects are
-ignored.}
+ignored. Alternatively a raw vector giving the data to transfer directly}
 
 \item{response}{(optional) a character vector specifying the response headers
 to return e.g. \code{c("date", "server")}. These are case-insensitive and
@@ -72,9 +72,19 @@ nano cURL - a minimalist http(s) client - async edition.
 
 The promises created are completely event-driven and non-polling.
 
-If a status code of 200 (OK) is returned then the promise is resolved with
-the reponse body, otherwise it is rejected with a translation of the status
-code or 'errorValue' as the case may be.
+The promise is resolved to a list with the following elements:
+\itemize{
+\item \verb{$status} - integer HTTP repsonse status code (200 - OK).
+Use \code{\link[=status_code]{status_code()}} for a translation of the meaning.
+\item \verb{$headers} - named list of response headers supplied in \code{response},
+or NULL otherwise. If the status code is within the 300 range, i.e. a
+redirect, the response header 'Location' is automatically appended to
+return the redirect address.
+\item \verb{$body} - the response body, as a character string if
+\code{convert = TRUE} (may be further parsed as html, json, xml etc. as
+required), or a raw byte vector if FALSE (use \code{\link[=writeBin]{writeBin()}} to save as a
+file).
+}
 }
 
 \examples{

--- a/man/ncurl_session.Rd
+++ b/man/ncurl_session.Rd
@@ -35,7 +35,7 @@ A non-character or non-named vector will be ignored.}
 
 \item{data}{(optional) character string request data to be submitted. If a
 vector, only the first element is taken, and non-character objects are
-ignored.}
+ignored. Alternatively a raw vector giving the data to transfer directly}
 
 \item{response}{(optional) a character vector specifying the response headers
 to return e.g. \code{c("date", "server")}. These are case-insensitive and

--- a/src/ncurl.c
+++ b/src/ncurl.c
@@ -1,5 +1,6 @@
 // nanonext - C level - ncurl --------------------------------------------------
 
+#include "Rinternals.h"
 #define NANONEXT_HTTP
 #include "nanonext.h"
 
@@ -55,6 +56,15 @@ static nano_buf nano_char_buf(const SEXP data) {
   nano_buf buf;
   const char *s = NANO_STRING(data);
   NANO_INIT(&buf, (unsigned char *) s, strlen(s));
+
+  return buf;
+
+}
+
+static nano_buf nano_raw_buf(const SEXP data) {
+
+  nano_buf buf;
+  NANO_INIT(&buf, RAW(data), Rf_xlength(data));
 
   return buf;
 
@@ -175,8 +185,11 @@ SEXP rnng_ncurl(SEXP http, SEXP convert, SEXP follow, SEXP method, SEXP headers,
       }
     }
   }
-  if (data != R_NilValue && TYPEOF(data) == STRSXP) {
-    nano_buf enc = nano_char_buf(data);
+  if (data != R_NilValue) {
+    nano_buf enc;
+    if (TYPEOF(data) == STRSXP) enc = nano_char_buf(data);
+    else if (TYPEOF(data) == RAWSXP) enc = nano_raw_buf(data);
+    else goto fail;
     if ((xc = nng_http_req_set_data(req, enc.buf, enc.cur)))
       goto fail;
   }
@@ -345,8 +358,11 @@ SEXP rnng_ncurl_aio(SEXP http, SEXP convert, SEXP method, SEXP headers, SEXP dat
       }
     }
   }
-  if (data != R_NilValue && TYPEOF(data) == STRSXP) {
-    nano_buf enc = nano_char_buf(data);
+  if (data != R_NilValue) {
+    nano_buf enc;
+    if (TYPEOF(data) == STRSXP) enc = nano_char_buf(data);
+    else if (TYPEOF(data) == RAWSXP) enc = nano_raw_buf(data);
+    else goto fail;
     if ((xc = nng_http_req_set_data(handle->req, enc.buf, enc.cur)))
       goto fail;
   }
@@ -550,8 +566,11 @@ SEXP rnng_ncurl_session(SEXP http, SEXP convert, SEXP method, SEXP headers, SEXP
       }
     }
   }
-  if (data != R_NilValue && TYPEOF(data) == STRSXP) {
-    nano_buf enc = nano_char_buf(data);
+  if (data != R_NilValue) {
+    nano_buf enc;
+    if (TYPEOF(data) == STRSXP) enc = nano_char_buf(data);
+    else if (TYPEOF(data) == RAWSXP) enc = nano_raw_buf(data);
+    else goto fail;
     if ((xc = nng_http_req_set_data(handle->req, enc.buf, enc.cur)))
       goto fail;
   }


### PR DESCRIPTION
This PR encompasses a couple of (in my opinion) improvements to how HTTP requests are handled.

Currently it makes the following changes:
- data can now be a raw vector instead of a string to avoid translating back and forth if the body is already in raw format
- The promise interface has been changed to return all relevant information from the response, instead of only the body. The response is now resolved to a list with the elements `status`, `headers`, and `body`. It no longer throws an error on non-2XX responses

I would love to have all headers returned by default (that is `response = NULL` returns all headers), but AFAIK NNG doesn't allow that for non-obvious reasons

This PR is mainly intended as an inspiration