### PR TITLE
Implements improved `ncurl_aio()` promises method

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,8 +2,8 @@
 
 #### Behavioural Changes
 
-* The promises method for `ncurlAio` has been updated for ease of use:
-  + Returns a named list of 'status', 'headers' and 'data'.
+* The promises method for `ncurlAio` has been updated for ease of use (#176):
+  + Returns a list of 'status', 'headers' and 'data'.
   + Rejects only if an NNG error is returned (all HTTP status codes are resolved).
 * Improved behaviour when using `serial_config()` configurations applied to a socket.
   If the serialization hook function errors or otherwise fails to return a raw vector, this will error out rather than be silently ignored (#173).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,15 @@
 # nanonext (development version)
 
-#### Updates
+#### Behavioural Changes
 
+* The promises method for `ncurlAio` has been updated for ease of use:
+  + Returns a named list of 'status', 'headers' and 'data'.
+  + Rejects only if an NNG error is returned (all HTTP status codes are resolved).
 * Improved behaviour when using `serial_config()` configurations applied to a socket.
   If the serialization hook function errors or otherwise fails to return a raw vector, this will error out rather than be silently ignored (#173).
+
+#### Updates
+
 * `as.promise()` method for `recvAio` and `ncurlAio` objects made robust for high-throughput cases (#171).
 
 # nanonext 1.6.2

--- a/R/ncurl.R
+++ b/R/ncurl.R
@@ -234,6 +234,10 @@ close.ncurlSession <- function(con, ...) invisible(.Call(rnng_ncurl_session_clos
 #' Allows an 'ncurlAio' to be used with functions such as `promises::then()`,
 #' which schedules a function to run upon resolution of the Aio.
 #'
+#' The promise is resolved with a list of 'status', 'headers' and 'data' or
+#' rejected with the error translation if an NNG error is returned e.g. for an
+#' invalid address.
+#'
 #' @param x an object of class 'ncurlAio'.
 #'
 #' @return A 'promise' object.

--- a/dev/vignettes/_nanonext.Rmd
+++ b/dev/vignettes/_nanonext.Rmd
@@ -475,13 +475,13 @@ In this respect, it may be used as a performant and lightweight method for makin
 
 `ncurl_aio()` may also be used anywhere that accepts a ‘promise’ from the promises package, including with Shiny ExtendedTask.
 
-If a status code of 200 (OK) is returned then the promise is resolved with the reponse body, otherwise it is rejected with a translation of the status code or ‘errorValue’ as the case may be.
+The promise is resolved with a list of 'status', 'headers' and 'data', or rejected with a translation of the error if an NNG error was returned e.g. for '15 | Address invalid'.
 
 ```{r}
 #| label: ncurlprom
 library(promises)
 
-p <- ncurl_aio("https://postman-echo.com/get") %...>% cat
+p <- ncurl_aio("https://postman-echo.com/get") |> then(\(x) cat(x$data))
 is.promise(p)
 ```
 ##### ncurl Session

--- a/man/as.promise.ncurlAio.Rd
+++ b/man/as.promise.ncurlAio.Rd
@@ -21,6 +21,6 @@ This function is an S3 method for the generic \code{as.promise} for class
 
 Requires the \pkg{promises} package.
 
-Allows an 'ncurlAio' to be used with the promise pipe \verb{\%...>\%}, which
-schedules a function to run upon resolution of the Aio.
+Allows an 'ncurlAio' to be used with functions such as \code{promises::then()},
+which schedules a function to run upon resolution of the Aio.
 }

--- a/man/as.promise.ncurlAio.Rd
+++ b/man/as.promise.ncurlAio.Rd
@@ -23,4 +23,8 @@ Requires the \pkg{promises} package.
 
 Allows an 'ncurlAio' to be used with functions such as \code{promises::then()},
 which schedules a function to run upon resolution of the Aio.
+
+The promise is resolved with a list of 'status', 'headers' and 'data' or
+rejected with the error translation if an NNG error is returned e.g. for an
+invalid address.
 }

--- a/man/ncurl_aio.Rd
+++ b/man/ncurl_aio.Rd
@@ -95,7 +95,8 @@ library(promises)
 p <- as.promise(nc)
 print(p)
 
-p2 <- ncurl_aio("https://postman-echo.com/get") \%...>\% cat
+p2 <- ncurl_aio("https://postman-echo.com/get") \%>\%
+  then(function(x) cat(x$data))
 is.promise(p2)
 \dontshow{\}) # examplesIf}
 }

--- a/src/sync.c
+++ b/src/sync.c
@@ -55,11 +55,15 @@ void raio_invoke_cb(void *arg) {
 
 void haio_invoke_cb(void *arg) {
 
-  SEXP call, status, node = (SEXP) arg, x = TAG(node);
-  status = nano_aio_http_status(x);
-  PROTECT(call = Rf_lcons(nano_ResolveSymbol, Rf_cons(status, R_NilValue)));
+  SEXP call, out, node = (SEXP) arg, x = TAG(node);
+  const char *names[] = {"status", "headers", "data", ""};
+  PROTECT(out = Rf_mkNamed(VECSXP, names));
+  SET_VECTOR_ELT(out, 0, nano_aio_http_status(x));
+  SET_VECTOR_ELT(out, 1, Rf_findVarInFrame(x, nano_ProtocolSymbol));
+  SET_VECTOR_ELT(out, 2, Rf_findVarInFrame(x, nano_ValueSymbol));
+  PROTECT(call = Rf_lcons(nano_ResolveSymbol, Rf_cons(out, R_NilValue)));
   Rf_eval(call, NANO_ENCLOS(x));
-  UNPROTECT(1);
+  UNPROTECT(2);
   nano_ReleaseObject(node);
 
 }

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -636,10 +636,10 @@ if (promises) test_true(is_aio(n <- ncurl_aio("https://www.cam.ac.uk/", timeout 
 if (promises) test_true(promises::is.promise(promises::then(n, identity, identity)))
 if (promises) test_true(promises::is.promising(call_aio(n)))
 if (promises) test_true(promises::is.promise(promises::as.promise(call_aio(ncurl_aio("https://www.cam.ac.uk/", timeout = 3000L)))))
-if (promises) later::run_now(1L)
+if (promises) { later::run_now(1L); later::run_now() }
 if (promises) test_zero(close(s1))
 if (promises) test_zero(close(s))
-if (promises) later::run_now(1L)
+if (promises) { later::run_now(1L); later::run_now() }
 test_type("character", ip_addr())
 test_type("character", names(ip_addr()))
 test_null(write_stdout(""))

--- a/vignettes/nanonext.Rmd
+++ b/vignettes/nanonext.Rmd
@@ -213,7 +213,7 @@ The return value from the server request is then retrieved and stored in the Aio
 
 ``` r
 call_aio(aio)$data |> str()
-#>  num [1:100000000] 0.145 0.959 -0.489 -0.896 1.245 ...
+#>  num [1:100000000] 1.2354 -0.0363 -0.9229 -0.3835 1.3604 ...
 ```
 
 As `call_aio()` is blocking and will wait for completion, an alternative is to query `aio$data` directly. This will return an 'unresolved' logical NA value if the calculation is yet to complete.
@@ -334,7 +334,7 @@ Additionally, the convenience function `write_cert()` can automatically generate
 cert <- write_cert(cn = "127.0.0.1")
 str(cert)
 #> List of 2
-#>  $ server: chr [1:2] "-----BEGIN CERTIFICATE-----\nMIIFOTCCAyGgAwIBAgIBATANBgkqhkiG9w0BAQsFADA0MRIwEAYDVQQDDAkxMjcu\nMC4wLjExETAPBgNV"| __truncated__ "-----BEGIN RSA PRIVATE KEY-----\nMIIJKQIBAAKCAgEAr4Spuk5e4qYBfuZ5Qe8QkPXE9APppdgEhXH0hkTcEsxb7Qf4\nF/s1SyUcWQUo"| __truncated__
+#>  $ server: chr [1:2] "-----BEGIN CERTIFICATE-----\nMIIFOTCCAyGgAwIBAgIBATANBgkqhkiG9w0BAQsFADA0MRIwEAYDVQQDDAkxMjcu\nMC4wLjExETAPBgNV"| __truncated__ "-----BEGIN RSA PRIVATE KEY-----\nMIIJKAIBAAKCAgEAnUy3if3SCAzwygcJQBQybALAwcxYRGxdwFa0kPc+tbqZ66YA\n402Jf8b+oNl/"| __truncated__
 #>  $ client: chr [1:2] "-----BEGIN CERTIFICATE-----\nMIIFOTCCAyGgAwIBAgIBATANBgkqhkiG9w0BAQsFADA0MRIwEAYDVQQDDAkxMjcu\nMC4wLjExETAPBgNV"| __truncated__ ""
 
 ser <- tls_config(server = cert$server)
@@ -495,7 +495,7 @@ ncurl("https://postman-echo.com/get")
 #> NULL
 #> 
 #> $data
-#> [1] "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1745415451.442\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-6808ed1b-16c5d32d02412c5d4e3a1f5d\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
+#> [1] "{\n  \"args\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1755250533.245\",\n    \"connection\": \"close\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-689eff65-353e08f93efc9a4b22a2632e\"\n  },\n  \"url\": \"https://postman-echo.com/get\"\n}"
 ```
 
 For advanced use, supports additional HTTP methods such as POST or PUT.
@@ -512,10 +512,10 @@ res
 
 call_aio(res)$headers
 #> $date
-#> [1] "Wed, 23 Apr 2025 13:37:31 GMT"
+#> [1] "Fri, 15 Aug 2025 09:35:33 GMT"
 
 res$data
-#> [1] "{\n  \"args\": {},\n  \"data\": {\n    \"key\": \"value\"\n  },\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1745415451.986\",\n    \"connection\": \"close\",\n    \"content-length\": \"16\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-6808ed1b-348ca7b6773f69bb06836afa\",\n    \"content-type\": \"application/json\",\n    \"authorization\": \"Bearer APIKEY\"\n  },\n  \"json\": {\n    \"key\": \"value\"\n  },\n  \"url\": \"https://postman-echo.com/post\"\n}"
+#> [1] "{\n  \"args\": {},\n  \"data\": {\n    \"key\": \"value\"\n  },\n  \"files\": {},\n  \"form\": {},\n  \"headers\": {\n    \"host\": \"postman-echo.com\",\n    \"x-request-start\": \"t1755250533.827\",\n    \"connection\": \"close\",\n    \"content-length\": \"16\",\n    \"x-forwarded-proto\": \"https\",\n    \"x-forwarded-port\": \"443\",\n    \"x-amzn-trace-id\": \"Root=1-689eff65-78c71ab742a40a275473017e\",\n    \"content-type\": \"application/json\",\n    \"authorization\": \"Bearer APIKEY\"\n  },\n  \"json\": {\n    \"key\": \"value\"\n  },\n  \"url\": \"https://postman-echo.com/post\"\n}"
 ```
 
 In this respect, it may be used as a performant and lightweight method for making REST API requests.
@@ -524,13 +524,13 @@ In this respect, it may be used as a performant and lightweight method for makin
 
 `ncurl_aio()` may also be used anywhere that accepts a ‘promise’ from the promises package, including with Shiny ExtendedTask.
 
-If a status code of 200 (OK) is returned then the promise is resolved with the reponse body, otherwise it is rejected with a translation of the status code or ‘errorValue’ as the case may be.
+The promise is resolved with a list of 'status', 'headers' and 'data', or rejected with a translation of the error if an NNG error was returned e.g. for '15 | Address invalid'.
 
 
 ``` r
 library(promises)
 
-p <- ncurl_aio("https://postman-echo.com/get") %...>% cat
+p <- ncurl_aio("https://postman-echo.com/get") |> then(\(x) cat(x$data))
 is.promise(p)
 #> [1] TRUE
 ```
@@ -555,24 +555,25 @@ transact(sess)
 #> 
 #> $headers
 #> $headers$Date
-#> [1] "Wed, 23 Apr 2025 13:37:32 GMT"
+#> [1] "Fri, 15 Aug 2025 09:35:34 GMT"
 #> 
 #> $headers$`Content-Type`
 #> [1] "application/json; charset=utf-8"
 #> 
 #> 
 #> $data
-#>   [1] 7b 0a 20 20 22 61 72 67 73 22 3a 20 7b 7d 2c 0a 20 20 22 68 65 61 64 65 72 73 22 3a 20 7b 0a 20 20 20 20 22
-#>  [37] 68 6f 73 74 22 3a 20 22 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 22 2c 0a 20 20 20 20 22 78 2d 72 65
-#>  [73] 71 75 65 73 74 2d 73 74 61 72 74 22 3a 20 22 74 31 37 34 35 34 31 35 34 35 32 2e 34 37 34 22 2c 0a 20 20 20
-#> [109] 20 22 63 6f 6e 6e 65 63 74 69 6f 6e 22 3a 20 22 63 6c 6f 73 65 22 2c 0a 20 20 20 20 22 78 2d 66 6f 72 77 61
-#> [145] 72 64 65 64 2d 70 72 6f 74 6f 22 3a 20 22 68 74 74 70 73 22 2c 0a 20 20 20 20 22 78 2d 66 6f 72 77 61 72 64
-#> [181] 65 64 2d 70 6f 72 74 22 3a 20 22 34 34 33 22 2c 0a 20 20 20 20 22 78 2d 61 6d 7a 6e 2d 74 72 61 63 65 2d 69
-#> [217] 64 22 3a 20 22 52 6f 6f 74 3d 31 2d 36 38 30 38 65 64 31 63 2d 34 64 64 34 37 61 35 34 33 34 32 33 36 32 37
-#> [253] 63 34 35 34 63 33 39 35 32 22 2c 0a 20 20 20 20 22 63 6f 6e 74 65 6e 74 2d 74 79 70 65 22 3a 20 22 61 70 70
-#> [289] 6c 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 22 2c 0a 20 20 20 20 22 61 75 74 68 6f 72 69 7a 61 74 69 6f 6e 22 3a
-#> [325] 20 22 42 65 61 72 65 72 20 41 50 49 4b 45 59 22 0a 20 20 7d 2c 0a 20 20 22 75 72 6c 22 3a 20 22 68 74 74 70
-#> [361] 73 3a 2f 2f 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 2f 67 65 74 22 0a 7d
+#>   [1] 7b 0a 20 20 22 61 72 67 73 22 3a 20 7b 7d 2c 0a 20 20 22 68 65 61 64 65 72 73 22 3a 20 7b 0a 20 20 20
+#>  [35] 20 22 68 6f 73 74 22 3a 20 22 70 6f 73 74 6d 61 6e 2d 65 63 68 6f 2e 63 6f 6d 22 2c 0a 20 20 20 20 22
+#>  [69] 78 2d 72 65 71 75 65 73 74 2d 73 74 61 72 74 22 3a 20 22 74 31 37 35 35 32 35 30 35 33 34 2e 32 34 39
+#> [103] 22 2c 0a 20 20 20 20 22 63 6f 6e 6e 65 63 74 69 6f 6e 22 3a 20 22 63 6c 6f 73 65 22 2c 0a 20 20 20 20
+#> [137] 22 78 2d 66 6f 72 77 61 72 64 65 64 2d 70 72 6f 74 6f 22 3a 20 22 68 74 74 70 73 22 2c 0a 20 20 20 20
+#> [171] 22 78 2d 66 6f 72 77 61 72 64 65 64 2d 70 6f 72 74 22 3a 20 22 34 34 33 22 2c 0a 20 20 20 20 22 78 2d
+#> [205] 61 6d 7a 6e 2d 74 72 61 63 65 2d 69 64 22 3a 20 22 52 6f 6f 74 3d 31 2d 36 38 39 65 66 66 36 36 2d 35
+#> [239] 65 63 63 35 39 36 63 37 65 38 34 62 32 36 34 35 61 34 35 30 61 37 33 22 2c 0a 20 20 20 20 22 63 6f 6e
+#> [273] 74 65 6e 74 2d 74 79 70 65 22 3a 20 22 61 70 70 6c 69 63 61 74 69 6f 6e 2f 6a 73 6f 6e 22 2c 0a 20 20
+#> [307] 20 20 22 61 75 74 68 6f 72 69 7a 61 74 69 6f 6e 22 3a 20 22 42 65 61 72 65 72 20 41 50 49 4b 45 59 22
+#> [341] 0a 20 20 7d 2c 0a 20 20 22 75 72 6c 22 3a 20 22 68 74 74 70 73 3a 2f 2f 70 6f 73 74 6d 61 6e 2d 65 63
+#> [375] 68 6f 2e 63 6f 6d 2f 67 65 74 22 0a 7d
 ```
 
 [&laquo; Back to ToC](#table-of-contents)


### PR DESCRIPTION
Closes #176.

The trick here is that as we resolve the promise from C (in a later call), we must construct the list in C on which to call resolve. We cannot resolve the Aio object itself, as that is "promising" and cannot be directly resolved.

The `$then` method is simplified and only needs to check for NNG errors. The reason we do this here is for Shiny deep stack trace support - the rejection cannot be made directly from a C level later callback. 