### PR TITLE
Interface cleanup post nanonext 1.7.0 / mirai 2.5.0

### DIFF
--- a/R/context.R
+++ b/R/context.R
@@ -177,8 +177,7 @@ reply <- function(
 #' @param timeout \[default NULL\] integer value in milliseconds or NULL, which
 #'   applies a socket-specific default, usually the same as no timeout.
 #' @param cv (optional) a 'conditionVariable' to signal when the async receive
-#'   is complete, or NULL. If any other value is supplied, this will cause the
-#'   pipe connection to be dropped when the async receive is complete.
+#'   is complete, or NULL.
 #' @param id (optional) set to `TRUE` (or any non-NULL value) to send a message
 #'   via the context upon timeout (asynchronously) consisting of an integer
 #'   zero, followed by the integer `context` ID.

--- a/man/request.Rd
+++ b/man/request.Rd
@@ -35,8 +35,7 @@ the other modes, received bytes are converted into the respective mode.
 applies a socket-specific default, usually the same as no timeout.}
 
 \item{cv}{(optional) a 'conditionVariable' to signal when the async receive
-is complete, or NULL. If any other value is supplied, this will cause the
-pipe connection to be dropped when the async receive is complete.}
+is complete, or NULL.}
 
 \item{id}{(optional) set to \code{TRUE} (or any non-NULL value) to send a message
 via the context upon timeout (asynchronously) consisting of an integer

--- a/src/aio.c
+++ b/src/aio.c
@@ -713,14 +713,8 @@ SEXP rnng_send_aio(SEXP con, SEXP data, SEXP mode, SEXP timeout, SEXP pipe, SEXP
 SEXP rnng_recv_aio(SEXP con, SEXP mode, SEXP timeout, SEXP cvar, SEXP bytes, SEXP clo) {
 
   const nng_duration dur = timeout == R_NilValue ? NNG_DURATION_DEFAULT : (nng_duration) nano_integer(timeout);
-  int signal, interrupt;
-  if (cvar == R_NilValue) {
-    signal = 0;
-    interrupt = 0;
-  } else {
-    signal = !NANO_PTR_CHECK(cvar, nano_CvSymbol);
-    interrupt = 1 - signal;
-  }
+  const int signal = cvar != R_NilValue && !NANO_PTR_CHECK(cvar, nano_CvSymbol);
+  const int interrupt = cvar == R_MissingArg;
   nano_cv *ncv = signal ? (nano_cv *) NANO_PTR(cvar) : NULL;
   nano_aio *raio = NULL;
   SEXP aio, env, fun;

--- a/src/sync.c
+++ b/src/sync.c
@@ -515,7 +515,6 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   PROTECT(aio = R_MakeExternalPtr(raio, nano_AioSymbol, NANO_PROT(con)));
   R_RegisterCFinalizerEx(aio, request_finalizer, TRUE);
   Rf_setAttrib(aio, nano_ContextSymbol, con);
-  Rf_setAttrib(aio, nano_IdSymbol, Rf_ScalarInteger(saio->id));
 
   PROTECT(env = R_NewEnv(R_NilValue, 0, 0));
   Rf_classgets(env, nano_reqAio);

--- a/src/sync.c
+++ b/src/sync.c
@@ -464,7 +464,7 @@ SEXP rnng_request(SEXP con, SEXP data, SEXP sendmode, SEXP recvmode, SEXP timeou
   const int raw = nano_encode_mode(sendmode);
   const int id = nng_ctx_id(*ctx);
   const int signal = cvar != R_NilValue && !NANO_PTR_CHECK(cvar, nano_CvSymbol);
-  const int drop = cvar != R_NilValue && !signal;
+  const int drop = cvar == R_MissingArg;
   int xc;
 
   nano_cv *ncv = signal ? (nano_cv *) NANO_PTR(cvar) : NULL;


### PR DESCRIPTION
Closes #181. Keeps internal behaviours internal.