### PR TITLE
Fix double free in `rnng_dial()` on failed TLS dial

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Fixes a blocking TLS `dial()` failure, e.g. connection refused, causing a process crash (#346).
 * `stop_aio()` no longer resets the R interrupt state.
 
 # nanonext 1.10.2

--- a/src/comms.c
+++ b/src/comms.c
@@ -151,6 +151,8 @@ SEXP rnng_dial(SEXP socket, SEXP url, SEXP tls, SEXP autostart, SEXP fail) {
     if (xc || (xc = nng_dialer_set_ptr(*dp, NNG_OPT_TLS_CONFIG, cfg)))
       goto fail;
     nng_url_free(up);
+    // NULL out as the fail path below frees `up` again
+    up = NULL;
     if (start && (xc = nng_dialer_start(*dp, start == 1 ? NNG_FLAG_NONBLOCK : 0)))
         goto fail;
     nng_tls_config_hold(cfg);


### PR DESCRIPTION
Fixes #346.