### PR TITLE
feat: add internal launch_server() to be compatible with _server.yml standard

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -39,7 +39,8 @@ Depends:
     R (>= 3.6)
 Suggests: 
     later,
-    litedown
+    litedown,
+    yaml12
 Enhances:
     promises
 VignetteBuilder: 

--- a/R/launch-server.R
+++ b/R/launch-server.R
@@ -1,0 +1,192 @@
+#' Launch a nanonext http server using the `_server.yml` standard
+#'
+#' Implements the `_server.yml` standard for R server frameworks, allowing a
+#' deployment platform to launch a \pkg{nanonext} server without knowing
+#' anything about its implementation. Reads the configuration, obtains the
+#' handlers, and serves in blocking mode until interrupted.
+#'
+#' @param settings character path to a `_server.yml` file.
+#' @param host default `NULL`. IP address or hostname to listen on, specified
+#'   without a URL scheme. If `NULL`, the `HOST` environment variable is used,
+#'   then the `host` option in `settings`, then "127.0.0.1".
+#' @param port \[default NULL\] port to listen on. If NULL, the `PORT`
+#'   environment variable is used, then the `port` option in `settings`, then
+#'   8080.
+#' @param ... additional arguments, currently unused.
+#'
+#' @return The server invisibly.
+#'
+#' @section Configuration:
+#'
+#' ```yaml
+#' engine: nanonext
+#' constructor: server.R
+#' options:
+#'   host: 127.0.0.1
+#'   port: 8080
+#'   tls:
+#'     server: cert-and-key.pem
+#' ```
+#'
+#' - `engine`: must be "nanonext".
+#' - `constructor` (required): path to an R file whose final expression evaluates to a
+#'   handler, or a list of handlers, as created by [handler()], [handler_ws()],
+#'   [handler_stream()] etc. Note that the constructor **must not** create a server.
+#' - `options` (optional): additional arguments passed to [http_server()]
+#'   - `host`: the host to serve the http server on.
+#'   - `port`: the port to serve the http server on.
+#'   - `tls`: the tls configuration arguments passed to [tls_config()]. If set,
+#'    the server will be served over https
+#'
+#' @details Requires the \pkg{yaml12} package.
+#' @keywords internal
+#' @noRd
+launch_server <- function(settings, host = NULL, port = NULL, ...) {
+  if (!is.character(settings)) {
+    stop("`settings` must be a path to a `_server.yml` file.")
+  }
+
+  if (length(settings) != 1L) {
+    stop("`settings` must be a scalar string.")
+  }
+
+  if (!file.exists(settings)) {
+    stop(sprintf("the file `%s` does not exist.", settings))
+  }
+
+  if (!requireNamespace("yaml12", quietly = TRUE)) {
+    stop("`launch_server()` requires `yaml12` to be installed.")
+  }
+
+  cfg <- yaml12::read_yaml(settings)
+
+  # every path in the configuration, and every relative path the constructor
+  # itself uses, is relative to the `_server.yml` file rather than the caller
+  owd <- setwd(dirname(settings))
+  on.exit(setwd(owd))
+
+  if (!identical(cfg$engine, "nanonext")) {
+    stop(sprintf(
+      "`engine` must be \"nanonext\", not `%s`.",
+      paste(format(cfg$engine), collapse = ", ")
+    ))
+  }
+
+  if (is.null(cfg$constructor)) {
+    stop("`settings` must specify a `constructor`.")
+  }
+
+  handlers <- constructor_handlers(cfg$constructor)
+
+  if (!length(handlers)) {
+    stop("`settings` did not produce any handlers.")
+  }
+
+  # only create the tls config if provided
+  # we use `$` because it will be null if not provided
+  cfg_tls <- cfg$options$tls
+  tls_opts <- if (!is.null(cfg_tls)) {
+    do.call(tls_config, tls_args(cfg_tls))
+  }
+
+  if (is.null(host)) {
+    env_host <- Sys.getenv("HOST")
+    host <- if (nzchar(env_host)) env_host else cfg$options$host
+  }
+
+  if (is.null(host)) {
+    host <- "127.0.0.1"
+  }
+
+  if (is.null(port)) {
+    env_port <- Sys.getenv("PORT")
+    port <- if (nzchar(env_port)) {
+      env_port
+    } else {
+      cfg$options$port
+    }
+  }
+
+  if (is.null(port)) {
+    port <- 8080L
+  }
+
+  if (!is.character(host) || length(host) != 1L) {
+    stop("`host` must be a scalar string.")
+  }
+
+  if (grepl("://", host, fixed = TRUE)) {
+    stop(sprintf("`host` must not include a URL scheme, found `%s`.", host))
+  }
+
+  # cast to integer
+  port <- suppressWarnings(as.integer(port))
+
+  if (length(port) != 1L || is.na(port) || port < 0L || port > 65535L) {
+    stop("`port` must be a scalar integer between 0 and 65535.")
+  }
+
+  # if tls is configured we use https
+  scheme <- if (is.null(cfg_tls$server)) {
+    "http"
+  } else {
+    "https"
+  }
+
+  # combine the args into a string that we will validate with the parse_url fx from nanonext
+  server_url <- sprintf("%s://%s:%d", scheme, host, port)
+  tryCatch(parse_url(server_url), error = function(e) {
+    stop(sprintf("unable to parse `%s` as a valid url.", server_url))
+  })
+
+  server <- http_server(server_url, handlers, tls = tls_opts)
+  server$serve()
+  invisible(server)
+}
+
+# utility handler to construct into
+constructor_handlers <- function(constructor) {
+  if (!is.character(constructor)) {
+    stop("`constructor` must be a path to an R file.")
+  }
+
+  if (length(constructor) != 1L) {
+    stop("`constructor` must be a scalar string.")
+  }
+
+  if (!file.exists(constructor)) {
+    stop(sprintf("the constructor `%s` does not exist.", constructor))
+  }
+
+  # sourced in its own environment so it cannot see or clobber our locals
+  env <- new.env(parent = globalenv())
+  handlers <- source(constructor, local = env)$value
+
+  # a single handler, rather than a list of them
+  if (is.integer(handlers$type)) {
+    handlers <- list(handlers)
+  }
+
+  if (!is.list(handlers) || !all(vapply(handlers, function(x) is.integer(x$type), logical(1L)))) {
+    stop(sprintf(
+      "the constructor `%s` must evaluate to a handler or list of handlers.",
+      constructor
+    ))
+  }
+
+  handlers
+}
+
+# validates the `tls` options as arguments to `tls_config()`.
+tls_args <- function(cfg_tls) {
+  if (!is.list(cfg_tls)) {
+    stop("`options$tls` must be a list of arguments to `tls_config()`.")
+  }
+
+  unknown <- setdiff(names(cfg_tls), names(formals(tls_config)))
+  if (length(unknown)) {
+    stop(sprintf("`options$tls` does not accept: %s.", paste(unknown, collapse = ", ")))
+  }
+
+  cfg_tls
+}

--- a/R/server.R
+++ b/R/server.R
@@ -101,8 +101,9 @@
 #' @export
 #'
 http_server <- function(url, handlers = list(), tls = NULL) {
-  if (is.integer(handlers$type))
+  if (is.integer(handlers$type)) {
     handlers <- list(handlers)
+  }
   srv <- .Call(rnng_http_server_create, url, handlers, tls)
   attr(srv, "start") <- function() {
     invisible(.Call(rnng_http_server_start, srv))
@@ -113,8 +114,10 @@ http_server <- function(url, handlers = list(), tls = NULL) {
   attr(srv, "serve") <- function() {
     on.exit(.Call(rnng_http_server_close, srv))
     .Call(rnng_http_server_start, srv)
-    cat(sprintf("Serving at %s - press Ctrl+C to stop\n", attr(srv, "url")))
-    repeat run_event_loop()
+    cat(sprintf("Serving at %s", attr(srv, "url")))
+    repeat {
+      run_event_loop()
+    }
   }
   srv
 }
@@ -135,7 +138,12 @@ http_server <- function(url, handlers = list(), tls = NULL) {
 #'
 #' @export
 #'
-run_event_loop <- function(timeout = Inf) later::run_now(timeout / 1000)
+run_event_loop <- function(timeout = Inf) {
+  if (!requireNamespace("later")) {
+    stop("The package \"later\" is required to run the event loop.")
+  }
+  later::run_now(timeout / 1000)
+}
 
 #' Create HTTP Handler
 #'
@@ -246,10 +254,15 @@ handler <- function(path, callback, method = "GET", prefix = FALSE) {
 #'
 #' @export
 #'
-handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL,
-                       textframes = FALSE) {
-  list(type = 2L, path = path, on_message = on_message, on_open = on_open,
-       on_close = on_close, textframes = textframes)
+handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL, textframes = FALSE) {
+  list(
+    type = 2L,
+    path = path,
+    on_message = on_message,
+    on_open = on_open,
+    on_close = on_close,
+    textframes = textframes
+  )
 }
 
 #' Create Static File Handler
@@ -269,10 +282,10 @@ handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL,
 #' @export
 #'
 handler_file <- function(path, file, prefix = FALSE) {
-  if (!file.exists(file))
+  if (!file.exists(file)) {
     warning("file does not exist: ", file)
-  list(type = 3L, path = path, file = normalizePath(file, mustWork = FALSE),
-       prefix = prefix)
+  }
+  list(type = 3L, path = path, file = normalizePath(file, mustWork = FALSE), prefix = prefix)
 }
 
 #' Create Static Directory Handler
@@ -303,10 +316,10 @@ handler_file <- function(path, file, prefix = FALSE) {
 #' @export
 #'
 handler_directory <- function(path, directory) {
-  if (!dir.exists(directory))
+  if (!dir.exists(directory)) {
     warning("directory does not exist: ", directory)
-  list(type = 4L, path = path,
-       directory = normalizePath(directory, mustWork = FALSE))
+  }
+  list(type = 4L, path = path, directory = normalizePath(directory, mustWork = FALSE))
 }
 
 #' Create Inline Static Content Handler
@@ -331,8 +344,7 @@ handler_directory <- function(path, directory) {
 #' @export
 #'
 handler_inline <- function(path, data, content_type = NULL, prefix = FALSE) {
-  list(type = 5L, path = path, data = data, content_type = content_type,
-       prefix = prefix)
+  list(type = 5L, path = path, data = data, content_type = content_type, prefix = prefix)
 }
 
 #' Create HTTP Redirect Handler
@@ -364,8 +376,9 @@ handler_inline <- function(path, data, content_type = NULL, prefix = FALSE) {
 #'
 handler_redirect <- function(path, location, status = 302L, prefix = FALSE) {
   status <- as.integer(status)
-  if (!status %in% c(301L, 302L, 303L, 307L, 308L))
+  if (!status %in% c(301L, 302L, 303L, 307L, 308L)) {
     stop("redirect status must be 301, 302, 303, 307, or 308")
+  }
   list(type = 6L, path = path, location = location, status = status, prefix = prefix)
 }
 
@@ -395,11 +408,13 @@ print.nanoWsConn <- function(x, ...) {
 #' @export
 #'
 `$.nanoWsConn` <- function(x, name) {
-  switch(name,
-         send = function(data) .Call(rnng_ws_send, x, data),
-         close = function() .Call(rnng_ws_close, x),
-         id = attr(x, "id"),
-         attr(x, name, exact = TRUE))
+  switch(
+    name,
+    send = function(data) .Call(rnng_ws_send, x, data),
+    close = function() .Call(rnng_ws_close, x),
+    id = attr(x, "id"),
+    attr(x, name, exact = TRUE)
+  )
 }
 
 #' Create HTTP Streaming Handler
@@ -489,10 +504,15 @@ print.nanoWsConn <- function(x, ...) {
 #'
 #' @export
 #'
-handler_stream <- function(path, on_request, on_close = NULL,
-                           method = "*", prefix = FALSE) {
-  list(type = 7L, path = path, on_request = on_request, on_close = on_close,
-       method = method, prefix = prefix)
+handler_stream <- function(path, on_request, on_close = NULL, method = "*", prefix = FALSE) {
+  list(
+    type = 7L,
+    path = path,
+    on_request = on_request,
+    on_close = on_close,
+    method = method,
+    prefix = prefix
+  )
 }
 
 #' Format Server-Sent Event
@@ -556,9 +576,15 @@ handler_stream <- function(path, on_request, on_close = NULL,
 #'
 format_sse <- function(data, event = NULL, id = NULL, retry = NULL) {
   parts <- character()
-  if (!is.null(event)) parts <- c(parts, paste0("event: ", event))
-  if (!is.null(id)) parts <- c(parts, paste0("id: ", id))
-  if (!is.null(retry)) parts <- c(parts, paste0("retry: ", as.integer(retry)))
+  if (!is.null(event)) {
+    parts <- c(parts, paste0("event: ", event))
+  }
+  if (!is.null(id)) {
+    parts <- c(parts, paste0("id: ", id))
+  }
+  if (!is.null(retry)) {
+    parts <- c(parts, paste0("retry: ", as.integer(retry)))
+  }
   lines <- strsplit(as.character(data), "\n", fixed = TRUE)[[1L]]
   parts <- c(parts, paste0("data: ", lines))
   paste0(paste(parts, collapse = "\n"), "\n\n")
@@ -575,12 +601,13 @@ print.nanoStreamConn <- function(x, ...) {
 #' @export
 #'
 `$.nanoStreamConn` <- function(x, name) {
-  switch(name,
-         send = function(data) .Call(rnng_stream_conn_send, x, data),
-         close = function() .Call(rnng_conn_close, x),
-         set_status = function(code) .Call(rnng_stream_conn_set_status, x, as.integer(code)),
-         set_header = function(name, value) .Call(rnng_stream_conn_set_header, x, name, value),
-         id = attr(x, "id"),
-         attr(x, name, exact = TRUE))
+  switch(
+    name,
+    send = function(data) .Call(rnng_stream_conn_send, x, data),
+    close = function() .Call(rnng_conn_close, x),
+    set_status = function(code) .Call(rnng_stream_conn_set_status, x, as.integer(code)),
+    set_header = function(name, value) .Call(rnng_stream_conn_set_header, x, name, value),
+    id = attr(x, "id"),
+    attr(x, name, exact = TRUE)
+  )
 }
-

--- a/R/server.R
+++ b/R/server.R
@@ -101,9 +101,8 @@
 #' @export
 #'
 http_server <- function(url, handlers = list(), tls = NULL) {
-  if (is.integer(handlers$type)) {
+  if (is.integer(handlers$type))
     handlers <- list(handlers)
-  }
   srv <- .Call(rnng_http_server_create, url, handlers, tls)
   attr(srv, "start") <- function() {
     invisible(.Call(rnng_http_server_start, srv))
@@ -114,10 +113,8 @@ http_server <- function(url, handlers = list(), tls = NULL) {
   attr(srv, "serve") <- function() {
     on.exit(.Call(rnng_http_server_close, srv))
     .Call(rnng_http_server_start, srv)
-    cat(sprintf("Serving at %s", attr(srv, "url")))
-    repeat {
-      run_event_loop()
-    }
+    cat(sprintf("Serving at %s - press Ctrl+C to stop\n", attr(srv, "url")))
+    repeat run_event_loop()
   }
   srv
 }
@@ -254,15 +251,10 @@ handler <- function(path, callback, method = "GET", prefix = FALSE) {
 #'
 #' @export
 #'
-handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL, textframes = FALSE) {
-  list(
-    type = 2L,
-    path = path,
-    on_message = on_message,
-    on_open = on_open,
-    on_close = on_close,
-    textframes = textframes
-  )
+handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL,
+                       textframes = FALSE) {
+  list(type = 2L, path = path, on_message = on_message, on_open = on_open,
+       on_close = on_close, textframes = textframes)
 }
 
 #' Create Static File Handler
@@ -282,10 +274,10 @@ handler_ws <- function(path, on_message, on_open = NULL, on_close = NULL, textfr
 #' @export
 #'
 handler_file <- function(path, file, prefix = FALSE) {
-  if (!file.exists(file)) {
+  if (!file.exists(file))
     warning("file does not exist: ", file)
-  }
-  list(type = 3L, path = path, file = normalizePath(file, mustWork = FALSE), prefix = prefix)
+  list(type = 3L, path = path, file = normalizePath(file, mustWork = FALSE),
+       prefix = prefix)
 }
 
 #' Create Static Directory Handler
@@ -316,10 +308,10 @@ handler_file <- function(path, file, prefix = FALSE) {
 #' @export
 #'
 handler_directory <- function(path, directory) {
-  if (!dir.exists(directory)) {
+  if (!dir.exists(directory))
     warning("directory does not exist: ", directory)
-  }
-  list(type = 4L, path = path, directory = normalizePath(directory, mustWork = FALSE))
+  list(type = 4L, path = path,
+       directory = normalizePath(directory, mustWork = FALSE))
 }
 
 #' Create Inline Static Content Handler
@@ -344,7 +336,8 @@ handler_directory <- function(path, directory) {
 #' @export
 #'
 handler_inline <- function(path, data, content_type = NULL, prefix = FALSE) {
-  list(type = 5L, path = path, data = data, content_type = content_type, prefix = prefix)
+  list(type = 5L, path = path, data = data, content_type = content_type,
+       prefix = prefix)
 }
 
 #' Create HTTP Redirect Handler
@@ -376,9 +369,8 @@ handler_inline <- function(path, data, content_type = NULL, prefix = FALSE) {
 #'
 handler_redirect <- function(path, location, status = 302L, prefix = FALSE) {
   status <- as.integer(status)
-  if (!status %in% c(301L, 302L, 303L, 307L, 308L)) {
+  if (!status %in% c(301L, 302L, 303L, 307L, 308L))
     stop("redirect status must be 301, 302, 303, 307, or 308")
-  }
   list(type = 6L, path = path, location = location, status = status, prefix = prefix)
 }
 
@@ -408,13 +400,11 @@ print.nanoWsConn <- function(x, ...) {
 #' @export
 #'
 `$.nanoWsConn` <- function(x, name) {
-  switch(
-    name,
-    send = function(data) .Call(rnng_ws_send, x, data),
-    close = function() .Call(rnng_ws_close, x),
-    id = attr(x, "id"),
-    attr(x, name, exact = TRUE)
-  )
+  switch(name,
+         send = function(data) .Call(rnng_ws_send, x, data),
+         close = function() .Call(rnng_ws_close, x),
+         id = attr(x, "id"),
+         attr(x, name, exact = TRUE))
 }
 
 #' Create HTTP Streaming Handler
@@ -504,15 +494,10 @@ print.nanoWsConn <- function(x, ...) {
 #'
 #' @export
 #'
-handler_stream <- function(path, on_request, on_close = NULL, method = "*", prefix = FALSE) {
-  list(
-    type = 7L,
-    path = path,
-    on_request = on_request,
-    on_close = on_close,
-    method = method,
-    prefix = prefix
-  )
+handler_stream <- function(path, on_request, on_close = NULL,
+                           method = "*", prefix = FALSE) {
+  list(type = 7L, path = path, on_request = on_request, on_close = on_close,
+       method = method, prefix = prefix)
 }
 
 #' Format Server-Sent Event
@@ -576,15 +561,9 @@ handler_stream <- function(path, on_request, on_close = NULL, method = "*", pref
 #'
 format_sse <- function(data, event = NULL, id = NULL, retry = NULL) {
   parts <- character()
-  if (!is.null(event)) {
-    parts <- c(parts, paste0("event: ", event))
-  }
-  if (!is.null(id)) {
-    parts <- c(parts, paste0("id: ", id))
-  }
-  if (!is.null(retry)) {
-    parts <- c(parts, paste0("retry: ", as.integer(retry)))
-  }
+  if (!is.null(event)) parts <- c(parts, paste0("event: ", event))
+  if (!is.null(id)) parts <- c(parts, paste0("id: ", id))
+  if (!is.null(retry)) parts <- c(parts, paste0("retry: ", as.integer(retry)))
   lines <- strsplit(as.character(data), "\n", fixed = TRUE)[[1L]]
   parts <- c(parts, paste0("data: ", lines))
   paste0(paste(parts, collapse = "\n"), "\n\n")
@@ -601,13 +580,12 @@ print.nanoStreamConn <- function(x, ...) {
 #' @export
 #'
 `$.nanoStreamConn` <- function(x, name) {
-  switch(
-    name,
-    send = function(data) .Call(rnng_stream_conn_send, x, data),
-    close = function() .Call(rnng_conn_close, x),
-    set_status = function(code) .Call(rnng_stream_conn_set_status, x, as.integer(code)),
-    set_header = function(name, value) .Call(rnng_stream_conn_set_header, x, name, value),
-    id = attr(x, "id"),
-    attr(x, name, exact = TRUE)
-  )
+  switch(name,
+         send = function(data) .Call(rnng_stream_conn_send, x, data),
+         close = function() .Call(rnng_conn_close, x),
+         set_status = function(code) .Call(rnng_stream_conn_set_status, x, as.integer(code)),
+         set_header = function(name, value) .Call(rnng_stream_conn_set_header, x, name, value),
+         id = attr(x, "id"),
+         attr(x, name, exact = TRUE))
 }
+

--- a/air.toml
+++ b/air.toml
@@ -4,6 +4,6 @@ indent-width = 2
 indent-style = "space"
 line-ending = "auto"
 persistent-line-breaks = false
-exclude = ["*"]
+# exclude = ["*"]
 default-exclude = true
 skip = []

--- a/air.toml
+++ b/air.toml
@@ -4,6 +4,6 @@ indent-width = 2
 indent-style = "space"
 line-ending = "auto"
 persistent-line-breaks = false
-# exclude = ["*"]
+exclude = ["*"]
 default-exclude = true
 skip = []

--- a/inst/examples/server-yml/_server.yml
+++ b/inst/examples/server-yml/_server.yml
@@ -1,0 +1,5 @@
+engine: nanonext
+constructor: server.R
+options:
+  host: 127.0.0.1
+  port: 8080

--- a/inst/examples/server-yml/server.R
+++ b/inst/examples/server-yml/server.R
@@ -1,0 +1,13 @@
+library(nanonext)
+
+list(
+  handler("/", function(req) {
+    list(status = 200L, body = "Hello, World!")
+  }),
+  handler("/api/data", function(req) {
+    list(status = 200L, headers = c("Content-Type" = "application/json"), body = '{"value": 42}')
+  }),
+  handler_ws("/ws", function(ws, data) ws$send(data), textframes = TRUE),
+  handler_inline("/robots.txt", "User-agent: *\nDisallow:\n", content_type = "text/plain"),
+  handler_directory("/static", "www")
+)

--- a/inst/examples/server-yml/www/index.html
+++ b/inst/examples/server-yml/www/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<title>nanonext</title>
+<h1>Static</h1>


### PR DESCRIPTION
This PR adds and internal `launch_server()` function that makes `nanoext` compatible with the [`_server.yaml`](https://posit-dev.github.io/plumber2/articles/server_yml.html) standard introduced by plumber2. 

Notably, the `_server.yml` is quite minimal and only `engine` and `constructor` are required.

```yaml
engine: nanonext
constructor: server.R
options:
  host: 127.0.0.1
  port: 8080
```

Per the standard, `engine` must be equal to the package name `nanonext`.
Then, the `constructor` is a path to an R script that creates a handler or a list of handlers that are passed to `http_server()`.

`options` captures host and port and `tls`.

To be able to read the `_server.yml`, `yaml12` is added as a suggested dependency.

Additionally, closes #348 

