### PR TITLE
Fix `ncurl()` double free on failed redirect follow-up (#351)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,7 @@
 #### Updates
 
 * Fixes a blocking TLS `dial()` failure, e.g. connection refused, causing a process crash (#346).
+* Fixes a `ncurl()` process crash when following a redirect to an unsupported URL (#351).
 * `stop_aio()` no longer resets the R interrupt state.
 
 # nanonext 1.10.2

--- a/src/ncurl.c
+++ b/src/ncurl.c
@@ -369,6 +369,7 @@ SEXP rnng_ncurl(SEXP http, SEXP convert, SEXP follow, SEXP method, SEXP headers,
   if (cfg != NULL)
     nng_tls_config_free(cfg);
   nng_aio_free(aio);
+  aio = NULL;
 
   code = nng_http_res_get_status(res), relo = code >= 300 && code < 400;
 


### PR DESCRIPTION
Fixes #351.

`rnng_ncurl()` freed the transaction aio after a successful request without resetting the pointer. When a followed redirect then failed in `nng_http_client_alloc()` before re-allocation, the cleanup path freed the dangling pointer again, aborting the R process.

Surfaced on CRAN's Fedora checks: the system libnng 1.12.2 there lacks a working TLS engine, so the 301 to an HTTPS URL fails with `NNG_ENOTSUP` and hits this path. The bug itself is long-standing and platform-independent.

Fix: reset `aio` to `NULL` after freeing, consistent with the existing null-after-free handling of `res`/`req`/`client`/`cfg` in the redirect path.