### PR TITLE
Probe system libnng for working TLS support in configure

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Our configure script now checks a detected system 'libnng' for working TLS support, falling back to the bundled build otherwise (#353).
 * Fixes a `ncurl()` process crash when following a redirect to an unsupported URL (#351).
 * Fixes a blocking TLS `dial()` failure, e.g. connection refused, causing a process crash (#346).
 * `stop_aio()` no longer resets the R interrupt state.

--- a/configure
+++ b/configure
@@ -231,7 +231,26 @@ int main() {
   if [ $? -ne 0 ]; then
     compile_nng=1
   else
-    echo "Found 'libnng' $NNG_SYS_CFLAGS"
+    # A system libnng can pass the version and link checks yet have no TLS at
+    # runtime: nng_tls_config_alloc() always exists, as an ENOTSUP stub if need
+    # be. Probe by running it -- any failure selects the bundled build.
+    if echo "#include <nng/nng.h>
+#include <nng/supplemental/tls/tls.h>
+int main(void) {
+    nng_tls_config *cfg;
+    if (nng_tls_config_alloc(&cfg, NNG_TLS_MODE_CLIENT) != 0)
+        return 1;
+    nng_tls_config_free(cfg);
+    return 0;
+}" | ${CC} ${NNG_SYS_CFLAGS} ${CFLAGS} -xc - ${LDFLAGS} ${NNG_SYS_LIBS} -o nano-tls-probe > /dev/null 2>&1 && \
+       LD_LIBRARY_PATH="${LIB_DIR:+$LIB_DIR:}$LD_LIBRARY_PATH" DYLD_LIBRARY_PATH="${LIB_DIR:+$LIB_DIR:}$DYLD_LIBRARY_PATH" \
+       ./nano-tls-probe > /dev/null 2>&1; then
+      echo "Found 'libnng' $NNG_SYS_CFLAGS"
+    else
+      compile_nng=1
+      echo "System 'libnng' has no working TLS ... building from source"
+    fi
+    rm -rf nano-tls-probe nano-tls-probe.dSYM
   fi
 fi
 


### PR DESCRIPTION
Fixes #353.

`configure` now probes a detected system `libnng` by actually running `nng_tls_config_alloc()`, falling back to the bundled build on any failure. A compile/link-only check cannot work: the broken library is link-identical to a working one (the `ENOTSUP` stubs are always compiled in, and no installed header records the engine choice).

Verified in a Fedora container with the real nng 1.12.2-1.fc44: the parent commit reproduces `tls_config()` error 9, while the patched configure reports `System 'libnng' has no working TLS ... building from source` and the bundled build passes TLS smoke tests.