### PR TITLE
Require Mbed TLS 3.x when detecting a system libmbedtls

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Our configure script now requires a system 'libmbedtls' 3.x, falling back to the bundled build when an incompatible version is detected (#350).
 * Our configure script now checks a detected system 'libnng' for working TLS support, falling back to the bundled build otherwise (#353).
 * Fixes a `ncurl()` process crash when following a redirect to an unsupported URL (#351).
 * Fixes a blocking TLS `dial()` failure, e.g. connection refused, causing a process crash (#346).

--- a/README.Rmd
+++ b/README.Rmd
@@ -130,7 +130,7 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system 'libnng' >= v1.12.0 and 'libmbedtls' >= v3.0.0 if present, otherwise compiles the bundled sources (libnng v1.12.0, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
+Uses a system 'libnng' >= v1.12.0 and 'libmbedtls' v3.x if present, otherwise compiles the bundled sources (libnng v1.12.0, libmbedtls v3.6.5) directly into the package - requiring only a C compiler.
 
 Recommended: Let the package compile bundled libraries for optimal performance:
 

--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ install.packages("nanonext", repos = "https://r-lib.r-universe.dev")
 
 #### Linux / Mac / Solaris
 
-Uses a system ‘libnng’ \>= v1.12.0 and ‘libmbedtls’ \>= v3.0.0 if
+Uses a system ‘libnng’ \>= v1.12.0 and ‘libmbedtls’ v3.x if
 present, otherwise compiles the bundled sources (libnng v1.12.0,
 libmbedtls v3.6.5) directly into the package - requiring only a C
 compiler.

--- a/configure
+++ b/configure
@@ -2,7 +2,7 @@
 
 # nanonext configure (POSIX / macOS / Emscripten).
 #
-# Uses a system 'libnng' >= 1.12 and 'libmbedtls' >= 3.0 when present; otherwise
+# Uses a system 'libnng' >= 1.12 and 'libmbedtls' 3.x when present; otherwise
 # compiles the bundled sources directly into nanonext.so via the explicit
 # per-object rules in src/Makevars.in -- no cmake, no static archives, no
 # install step. The only genuinely platform-specific work is replicating NNG's
@@ -205,9 +205,11 @@ else
   MBEDTLS_SYS_CFLAGS="$LIB_CFLAGS"
   MBEDTLS_SYS_LIBS="$LIB_LIBS"
 
+  # Require Mbed TLS 3.x: 4.x removed the legacy crypto headers (rsa.h etc.)
+  # and APIs that src/tls.c and the bundled NNG TLS engine rely on.
   echo "#include <mbedtls/version.h>
 int main() {
-#if MBEDTLS_VERSION_MAJOR < 3
+#if MBEDTLS_VERSION_MAJOR != 3
     *(void *) 0 = 0;
 #endif
 }" | ${CC} ${MBEDTLS_SYS_CFLAGS} -xc - -o /dev/null > /dev/null 2>&1


### PR DESCRIPTION
Fixes #350. Newer MbedTLS is not supported by the current release of NNG.