### PR TITLE
Fix erroring unserialization hook halting non-interactive R processes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 #### Updates
 
+* Fixes an erroring unserialization hook (`ufunc`) halting non-interactive R processes; the object now unserializes as an 'errorValue' (#356).
 * Our configure script now requires a system 'libmbedtls' 3.x, falling back to the bundled build when an incompatible version is detected (#350).
 * Our configure script now checks a detected system 'libnng' for working TLS support, falling back to the bundled build otherwise (#353).
 * Fixes a `ncurl()` process crash when following a redirect to an unsupported URL (#351).

--- a/R/utils.R
+++ b/R/utils.R
@@ -257,6 +257,13 @@ status_code <- function(x) .Call(rnng_status_code, x)
 #'
 #' This feature utilises the 'refhook' system of R native serialization.
 #'
+#' If `sfunc` errors during serialization, the error propagates to the caller
+#' and no message is sent.
+#'
+#' If `ufunc` errors during unserialization, the error is caught and the
+#' object instead unserializes as an 'errorValue' 1000 ('Internal error
+#' detected'), rather than the error propagating to the caller.
+#'
 #' @param class a character string (or vector) of the class of object custom
 #'   serialization functions are applied to, e.g. `'ArrowTabular'` or
 #'   `c('torch_tensor', 'ArrowTabular')`.

--- a/man/serial_config.Rd
+++ b/man/serial_config.Rd
@@ -30,6 +30,13 @@ set, the functions apply to all send and receive operations performed in mode
 }
 \details{
 This feature utilises the 'refhook' system of R native serialization.
+
+If \code{sfunc} errors during serialization, the error propagates to the caller
+and no message is sent.
+
+If \code{ufunc} errors during unserialization, the error is caught and the
+object instead unserializes as an 'errorValue' 1000 ('Internal error
+detected'), rather than the error propagating to the caller.
 }
 \examples{
 cfg <- serial_config("test_cls", function(x) serialize(x, NULL), unserialize)

--- a/src/core.c
+++ b/src/core.c
@@ -174,10 +174,11 @@ static SEXP nano_unserialize_hook(SEXP x, SEXP hook_func) {
   InBytes(stream, buf, 20);
 
   PROTECT(call = Rf_lcons(VECTOR_PTR_RO(hook_func)[i], Rf_cons(raw, R_NilValue)));
-  out = Rf_eval(call, R_GlobalEnv);
+  const Rboolean ok = R_ToplevelExec(nano_eval_safe, call);
+  out = nano_eval_res;
 
   UNPROTECT(2);
-  return out;
+  return ok ? out : mk_error(NNG_EINTERNAL);
 
 }
 

--- a/tests/tests.R
+++ b/tests/tests.R
@@ -296,6 +296,21 @@ test_error(send(req$socket, `class<-`(new.env(), "string_class"), block = 500), 
 opt(req$socket, "serial") <- cfg
 opt(req$socket, "serial") <- list()
 opt(rep, "serial") <- list()
+cfg <- serial_config("ufunc_error", function(x) raw(1L), function(x) stop("hook failure"))
+opt(req$socket, "serial") <- cfg
+opt(rep, "serial") <- cfg
+test_zero(send(req$socket, `class<-`(new.env(), "ufunc_error"), mode = "serial", block = 500))
+test_class("errorValue", res <- recv(rep, mode = "serial", block = 500))
+test_equal(res, 1000L)
+test_zero(send(req$socket, list(`class<-`(new.env(), "ufunc_error"), "ok"), mode = "serial", block = 500))
+test_type("list", res <- recv(rep, mode = "serial", block = 500))
+test_class("errorValue", res[[1L]])
+test_equal(res[[1L]], 1000L)
+test_equal(res[[2L]], "ok")
+test_zero(send(req$socket, "next message", mode = "serial", block = 500))
+test_equal(recv(rep, mode = "serial", block = 500), "next message")
+opt(req$socket, "serial") <- list()
+opt(rep, "serial") <- list()
 test_error(serial_config(1L, identity, identity), "must be a character vector")
 test_error(serial_config(c("custom", "custom2"), list(identity), list(identity)), "must all be the same length")
 test_error(serial_config("custom", "func1", "func2"), "must be a function or list of functions")


### PR DESCRIPTION
Fixes #356. Wraps the `ufunc` invocation in `R_ToplevelExec` to prevent it long jumping.